### PR TITLE
Wait for pod to complete before fetching exit code

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    k8s_kit (0.0.3)
+    k8s_kit (0.0.6)
       gli (= 2.18.1)
 
 GEM
@@ -49,6 +49,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
     thor (0.20.3)
+    waitutil (0.2.1)
 
 PLATFORMS
   ruby
@@ -59,6 +60,7 @@ DEPENDENCIES
   k8s_kit!
   rake
   rdoc
+  waitutil
 
 BUNDLED WITH
    2.0.2

--- a/k8s_kit.gemspec
+++ b/k8s_kit.gemspec
@@ -19,4 +19,5 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency('rdoc')
   s.add_development_dependency('aruba')
   s.add_runtime_dependency('gli','2.18.1')
+  s.add_runtime_dependency('waitutil')
 end

--- a/lib/k8s_kit/job.rb
+++ b/lib/k8s_kit/job.rb
@@ -1,3 +1,5 @@
+require 'waitutil'
+
 module K8sKit
   class Job
     attr_reader :context, :name
@@ -10,6 +12,13 @@ module K8sKit
     def attach(container:, delete_on_completion: true, exit_on_completion: true)
       pod.wait_until_ready
       pod.logs(container: container, stream: true)
+
+      WaitUtil.wait_for_condition("pod has exit code", 
+                            :timeout_sec => 30,
+                            :delay_sec => 0.5) do
+        pod.exit_code(container: container) != nil
+      end
+
       exit_code = pod.exit_code(container: container)
 
       delete if delete_on_completion

--- a/lib/k8s_kit/pod.rb
+++ b/lib/k8s_kit/pod.rb
@@ -21,7 +21,7 @@ module K8sKit
 
     def exit_code(container:)
       json_path = "{ .status.containerStatuses[?(@.name == '#{container}')].state.terminated.exitCode }"
-      context.run("get pod #{name} -o jsonpath=\"#{json_path}\"").to_i
+      Integer(context.run("get pod #{name} -o jsonpath=\"#{json_path}\""))
     rescue StandardError
       nil
     end

--- a/lib/k8s_kit/version.rb
+++ b/lib/k8s_kit/version.rb
@@ -1,3 +1,3 @@
 module K8sKit
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
 end


### PR DESCRIPTION
After streaming all logs from a container, an exit code isn't always immediately available
1) Fix bug where empty string exit codes were converted to 0 (now return nil)
2) Wait up to 30s for an exit code to appear on the target container before asserting its value

Prepared for version 0.0.6 